### PR TITLE
カリキュラム8-5　ブログ投稿ページshow textareaタグ　初期値修正

### DIFF
--- a/resources/views/posts/create.blade.php
+++ b/resources/views/posts/create.blade.php
@@ -18,7 +18,7 @@
                 </div>
                 <div class="body">
                   <h2>Body</h2>
-                  <textarea name="post[body]" placeholder="今日も1日お疲れさまでした。" value="{{ old('post.body') }}"></textarea>
+                  <textarea name="post[body]" placeholder="今日も1日お疲れさまでした。">{{ old('post.body') }}</textarea>
                   <p class="body__error" style="color:red">{{ $errors->first('post.body') }}</p>
                 </div>
             </div>


### PR DESCRIPTION
カリキュラム8-5　ブログ投稿ページ　修正

textareaタグの初期値について、誤ってvalue属性を用いていた。
<textarea ~>　この部分　</textarea>　で挟む形に直した。